### PR TITLE
⚡ Bolt: Fix Carousel Image Loading Priority

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -23,6 +23,7 @@ interface ProjectCardProps {
 
 export const ProjectCard: React.FC<ProjectCardProps> = ({
   href,
+  priority,
   images = [],
   title,
   content,
@@ -33,6 +34,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
   return (
     <Column fillWidth gap="m">
       <Carousel
+        priority={priority}
         sizes="(max-width: 960px) 100vw, 960px"
         images={images.map((image) => ({
           src: image,

--- a/src/once-ui/components/Carousel.tsx
+++ b/src/once-ui/components/Carousel.tsx
@@ -14,6 +14,7 @@ interface CarouselProps extends React.ComponentProps<typeof Flex> {
   aspectRatio?: string;
   sizes?: string;
   revealedByDefault?: boolean;
+  priority?: boolean;
 }
 
 const Carousel: React.FC<CarouselProps> = ({
@@ -22,6 +23,7 @@ const Carousel: React.FC<CarouselProps> = ({
   aspectRatio = "16 / 9",
   sizes,
   revealedByDefault = false,
+  priority = false,
   ...rest
 }) => {
   const [activeIndex, setActiveIndex] = useState<number>(0);
@@ -89,7 +91,7 @@ const Carousel: React.FC<CarouselProps> = ({
       >
         <SmartImage
           sizes={sizes}
-          priority
+          priority={priority}
           radius="l"
           border="neutral-alpha-weak"
           alt={images[activeIndex]?.alt}


### PR DESCRIPTION
⚡ Bolt Optimization: Fix Carousel Image Loading Priority

💡 What:
Updated `Carousel` component to accept a `priority` prop and pass it to the underlying `SmartImage`.
Updated `ProjectCard` component to pass the `priority` prop it receives to the `Carousel`.

🎯 Why:
Previously, `Carousel` hardcoded `priority` to true for its main image. This meant that EVERY project card on the page (even those below the fold) was eagerly loading its first image, causing LCP resource contention and delaying the initial page load.
The `Projects` component was correctly passing `priority={index < 2}` to `ProjectCard`, but `ProjectCard` was ignoring it (in the Carousel usage).

📊 Impact:
Reduces LCP resource contention. Images for projects below the fold (index >= 2) will now be lazy-loaded, freeing up bandwidth for the actual LCP element (the first 1-2 projects and hero section).

🔬 Measurement:
- Verify that `img` tags for the first 2 projects have `fetchpriority="high"` (or similar `next/image` optimization).
- Verify that `img` tags for subsequent projects have `loading="lazy"`.

---
*PR created automatically by Jules for task [1680176579694311535](https://jules.google.com/task/1680176579694311535) started by @bimadevs*