### PR TITLE
🎨 Palette: Make Carousel indicators accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-18 - Mobile Navigation Accessibility
 **Learning:** Icon-only buttons in the mobile navigation (Header.tsx) were missing accessible names, making them invisible to screen readers.
 **Action:** When creating icon-only toggles/buttons, always ensure `aria-label` is provided, especially if the `label` prop is omitted for visual reasons.
+
+## 2025-05-19 - Interactive Lists Accessibility
+**Learning:** Custom interactive lists (like Carousel indicators) often lack semantic meaning and keyboard support. `div`s with `onClick` are not buttons.
+**Action:** Always add `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` handlers to non-semantic interactive elements.

--- a/src/once-ui/components/Carousel.tsx
+++ b/src/once-ui/components/Carousel.tsx
@@ -122,6 +122,16 @@ const Carousel: React.FC<CarouselProps> = ({
                   cursor="interactive"
                   fillWidth
                   height="2"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Go to slide ${index + 1}`}
+                  aria-current={activeIndex === index ? "true" : undefined}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleControlClick(index);
+                    }
+                  }}
                 ></Flex>
               ))}
             </Flex>
@@ -139,6 +149,16 @@ const Carousel: React.FC<CarouselProps> = ({
                   padding="4"
                   width="80"
                   height="80"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Go to slide ${index + 1}`}
+                  aria-current={activeIndex === index ? "true" : undefined}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleControlClick(index);
+                    }
+                  }}
                 >
                   <SmartImage
                     alt={image.alt}


### PR DESCRIPTION
💡 What: Added accessibility attributes and keyboard support to the Carousel component's indicators.
🎯 Why: Keyboard users and screen readers could not navigate the carousel images as the indicators were non-semantic `div`s with only mouse events.
📸 Before/After: Visually identical, but now interactive via keyboard (tab to focus, enter/space to select).
♿ Accessibility:
    - Added `role="button"` to indicate interactivity.
    - Added `tabIndex={0}` to make indicators focusable.
    - Added `aria-label` for descriptive accessible names (e.g., "Go to slide 1").
    - Added `aria-current` to indicate the currently active slide.
    - Added `onKeyDown` handler for Enter/Space key activation.

---
*PR created automatically by Jules for task [12192418698865271671](https://jules.google.com/task/12192418698865271671) started by @bimadevs*