### PR TITLE
🎨 Palette: Add accessible labels to icon-only buttons in About page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-19 - Interactive Lists Accessibility
 **Learning:** Custom interactive lists (like Carousel indicators) often lack semantic meaning and keyboard support. `div`s with `onClick` are not buttons.
 **Action:** Always add `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` handlers to non-semantic interactive elements.
+
+## 2025-05-27 - IconButton Default Labels
+**Learning:** The `IconButton` component falls back to the icon name (e.g., "chevronRight") if no `aria-label` or `tooltip` is provided, which provides poor context to screen readers.
+**Action:** Always verify the computed accessible name of `IconButton`s. If the icon name is generic, explicitly provide `aria-label`.

--- a/dev_server.log
+++ b/dev_server.log
@@ -7,28 +7,51 @@
 
  ✓ Starting...
    automatically enabled Fast Refresh for 1 custom loader
- ✓ Ready in 1897ms
- ○ Compiling / ...
-request to https://fonts.gstatic.com/s/sourcecodepro/v31/HI_SiYsKILxRpg3hIP6sJ7fM7PqlOevWnsUnxlC9.woff2 failed, reason:
-
-Retrying 1/3...
-request to https://fonts.gstatic.com/s/sourcecodepro/v31/HI_SiYsKILxRpg3hIP6sJ7fM7PqlMOvWnsUnxlC9.woff2 failed, reason:
-
-Retrying 1/3...
-request to https://fonts.gstatic.com/s/sourcecodepro/v31/HI_SiYsKILxRpg3hIP6sJ7fM7PqlMevWnsUnxlC9.woff2 failed, reason:
-
-Retrying 1/3...
-request to https://fonts.gstatic.com/s/sourcecodepro/v31/HI_SiYsKILxRpg3hIP6sJ7fM7PqlPuvWnsUnxlC9.woff2 failed, reason:
-
-Retrying 1/3...
-request to https://fonts.gstatic.com/s/sourcecodepro/v31/HI_SiYsKILxRpg3hIP6sJ7fM7PqlMuvWnsUnxlC9.woff2 failed, reason:
-
-Retrying 1/3...
-request to https://fonts.gstatic.com/s/sourcecodepro/v31/HI_SiYsKILxRpg3hIP6sJ7fM7PqlM-vWnsUnxlC9.woff2 failed, reason:
-
-Retrying 1/3...
-request to https://fonts.gstatic.com/s/sourcecodepro/v31/HI_SiYsKILxRpg3hIP6sJ7fM7PqlPevWnsUnxg.woff2 failed, reason:
-
-Retrying 1/3...
- ✓ Compiled / in 89.8s (2264 modules)
- GET / 200 in 37882ms
+ ✓ Ready in 1947ms
+ ○ Compiling /about ...
+ ✓ Compiled /about in 80.2s (1418 modules)
+Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
+ GET /about 200 in 126ms
+ ○ Compiling /_not-found ...
+ ✓ Compiled /_not-found in 13s (976 modules)
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 13463ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 29ms
+Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
+ GET /about 200 in 85ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 56ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 126ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 118ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 31ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 39ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 35ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 33ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 32ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 28ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 25ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 26ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 26ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 23ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 24ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 26ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 25ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 32ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 24ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 26ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 30ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 44ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 34ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 24ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 40ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 29ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 36ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 28ms
+ GET /about 200 in 54ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 44ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 164ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 28ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 40ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 372ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 80ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 346ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 38ms
+ GET /_next/static/css/app/about/images/logo-color.png 404 in 28ms

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -167,6 +167,7 @@ export default function About() {
                   data-border="rounded"
                   variant="secondary"
                   icon="chevronRight"
+                  aria-label="Schedule a call"
                 />
               </Flex>
             )}
@@ -202,6 +203,7 @@ export default function About() {
                           href={item.link}
                           icon={item.icon}
                           variant="secondary"
+                          aria-label={item.name}
                         />
                       </>
                     ),


### PR DESCRIPTION
* 💡 **What**: Added `aria-label` to the Calendar IconButton and Social IconButtons in the About page.
* 🎯 **Why**: Screen reader users rely on accessible names. Defaulting to icon names (like "chevronRight") or having no label makes these buttons confusing or unusable.
* 📸 **Before/After**: No visual change.
* ♿ **Accessibility**: Improved screen reader experience by providing descriptive labels ("Schedule a call", "Instagram", etc.).

---
*PR created automatically by Jules for task [7598205386350608144](https://jules.google.com/task/7598205386350608144) started by @bimadevs*