### PR TITLE
🎨 Palette: Accessible Project Links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-19 - Interactive Lists Accessibility
 **Learning:** Custom interactive lists (like Carousel indicators) often lack semantic meaning and keyboard support. `div`s with `onClick` are not buttons.
 **Action:** Always add `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` handlers to non-semantic interactive elements.
+
+## 2025-05-20 - Ambiguous Link Text
+**Learning:** Generic link text like "Read more" or "View project" creates confusion for screen reader users when navigated out of context.
+**Action:** Always attach descriptive `aria-label` props to generic links (e.g., `aria-label={`Read more about ${title}`}`).

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -67,6 +67,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
             <Flex gap="24" wrap>
               {content?.trim() && (
                 <SmartLink
+                  aria-label={`Read more about ${title}`}
                   suffixIcon="arrowRight"
                   style={{ margin: "0", width: "fit-content" }}
                   href={href}
@@ -76,6 +77,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
               )}
               {link && (
                 <SmartLink
+                  aria-label={`View project: ${title}`}
                   suffixIcon="arrowUpRightFromSquare"
                   style={{ margin: "0", width: "fit-content" }}
                   href={link}


### PR DESCRIPTION
🎨 **Palette Enhancement: Accessible Project Links**

**💡 What:**
Added `aria-label` attributes to the "Read more" and "View project" links in the `ProjectCard` component.

**🎯 Why:**
Generic link text like "Read more" is confusing for screen reader users when navigating out of context. By adding the project title to the label (e.g., "Read more about Project X"), users can understand the link's purpose without needing surrounding context.

**♿ Accessibility:**
- Compliant with WCAG 2.4.4 (Link Purpose).
- Improves navigation for screen reader users.

**📸 Verification:**
- `pnpm lint` passed.
- `pnpm build` passed.
- Manual code inspection confirms `aria-label` is correctly applied.

---
*PR created automatically by Jules for task [11670958048995099997](https://jules.google.com/task/11670958048995099997) started by @bimadevs*