### PR TITLE
Improve Carousel accessibility for keyboard users

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Interactive Wrappers Accessibility
+**Learning:** The design system uses `RevealFx` and `Flex` as interactive wrappers (e.g. in Carousel). These components render `div`s by default and do not automatically handle accessibility for interactive states.
+**Action:** When making `RevealFx` or `Flex` interactive (onClick), always manually add `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` handler for keyboard support.

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,14 @@
+
+> BimaDev Portfolio@1.3.0 dev /app
+> next dev
+
+  ▲ Next.js 14.2.35
+  - Local:        http://localhost:3000
+
+ ✓ Starting...
+   automatically enabled Fast Refresh for 1 custom loader
+ ✓ Ready in 1692ms
+ ○ Compiling /work/[slug] ...
+ ✓ Compiled / in 90.5s (1875 modules)
+ GET / 200 in 61ms
+ GET / 200 in 56ms

--- a/src/once-ui/components/Carousel.tsx
+++ b/src/once-ui/components/Carousel.tsx
@@ -77,6 +77,21 @@ const Carousel: React.FC<CarouselProps> = ({
     <Flex fillWidth gap="12" direction="column" {...rest}>
       <RevealFx
         onClick={handleImageClick}
+        onKeyDown={(e) => {
+          if (images.length > 1) {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleImageClick();
+            }
+          }
+        }}
+        role={images.length > 1 ? "button" : undefined}
+        tabIndex={images.length > 1 ? 0 : undefined}
+        aria-label={
+          images.length > 1
+            ? `Next slide: ${images[activeIndex]?.alt}`
+            : undefined
+        }
         fillWidth
         trigger={isTransitioning}
         translateY="16"


### PR DESCRIPTION
Improved the accessibility of the `Carousel` component by making the main image area keyboard-accessible when there are multiple slides. Previously, only mouse users could click the image to advance. Now, keyboard users can focus the image area and use Enter or Space to go to the next slide.

Changes:
- Added `role="button"`, `tabIndex={0}` to the `RevealFx` wrapper of the main image.
- Added `aria-label` with the format "Next slide: [Image Alt Text]".
- Added `onKeyDown` handler for Enter/Space key support.

---
*PR created automatically by Jules for task [9817600704550516141](https://jules.google.com/task/9817600704550516141) started by @bimadevs*