### PR TITLE
🎨 Palette: Enhance Input Accessibility

### DIFF
--- a/src/once-ui/components/Input.tsx
+++ b/src/once-ui/components/Input.tsx
@@ -108,6 +108,14 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     }, [debouncedValue, validateInput]);
 
     const displayError = validationError || errorMessage;
+    const isErrorVisible = displayError && errorMessage !== false;
+    const ariaDescribedBy =
+      [
+        isErrorVisible ? `${id}-error` : undefined,
+        description ? `${id}-description` : undefined,
+      ]
+        .filter(Boolean)
+        .join(" ") || undefined;
 
     const inputClassNames = classNames(styles.input, "font-body", "font-default", "font-m", {
       [styles.filled]: isFilled,
@@ -163,7 +171,8 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={inputClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-label={labelAsPlaceholder ? label : undefined}
+              aria-describedby={ariaDescribedBy}
               aria-invalid={!!displayError}
             />
             {!labelAsPlaceholder && (


### PR DESCRIPTION
🎨 **Palette: Input Accessibility Enhancements**

💡 **What:**
- Modified `src/once-ui/components/Input.tsx` to automatically set `aria-label` to the `label` text when `labelAsPlaceholder` is active.
- Updated `aria-describedby` logic to dynamically chain IDs for both the error message and the description text.

🎯 **Why:**
- Inputs using the `labelAsPlaceholder` pattern (like the newsletter form) lacked an accessible name, making them hard to use for screen reader users.
- Error messages and descriptions were mutually exclusive in `aria-describedby`, meaning users might miss context or error details.

♿ **Accessibility:**
- Ensures all inputs have an accessible name even when the visual label is hidden.
- correctly associates error messages and descriptions with the input field for screen readers.


---
*PR created automatically by Jules for task [18368295389536015655](https://jules.google.com/task/18368295389536015655) started by @bimadevs*