### PR TITLE
fix(a11y): improve Input and Textarea accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility in Form Inputs
+**Learning:** `aria-describedby` is often overlooked when linking descriptions to inputs. Simply rendering a description with an ID isn't enough; it must be explicitly linked in the `aria-describedby` attribute of the input. Also, using labels as placeholders (`labelAsPlaceholder`) can strip semantic meaning for screen readers if not compensated with an `aria-label`.
+**Action:** When creating or modifying input components, always ensure `aria-describedby` includes IDs for both error messages and descriptions. If a visual label is hidden or used as a placeholder, ensure `aria-label` provides the necessary context.

--- a/src/once-ui/components/Input.tsx
+++ b/src/once-ui/components/Input.tsx
@@ -109,6 +109,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     const displayError = validationError || errorMessage;
 
+    const ariaDescribedBy = [
+      displayError ? `${id}-error` : undefined,
+      description ? `${id}-description` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
     const inputClassNames = classNames(styles.input, "font-body", "font-default", "font-m", {
       [styles.filled]: isFilled,
       [styles.focused]: isFocused,
@@ -163,8 +170,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={inputClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={ariaDescribedBy}
               aria-invalid={!!displayError}
+              aria-label={props["aria-label"] || (labelAsPlaceholder ? label : undefined)}
             />
             {!labelAsPlaceholder && (
               <Text

--- a/src/once-ui/components/Textarea.tsx
+++ b/src/once-ui/components/Textarea.tsx
@@ -125,6 +125,13 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     const displayError = validationError || errorMessage;
 
+    const ariaDescribedBy = [
+      displayError ? `${id}-error` : undefined,
+      description ? `${id}-description` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
     const textareaClassNames = classNames(
       styles.input,
       styles.textarea,
@@ -189,8 +196,9 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={textareaClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={ariaDescribedBy}
               aria-invalid={!!displayError}
+              aria-label={props["aria-label"] || (labelAsPlaceholder ? label : undefined)}
               style={{
                 ...style,
                 resize: lines === "auto" ? "none" : resize,


### PR DESCRIPTION
This PR improves the accessibility of `Input` and `Textarea` components in `src/once-ui`.
It addresses two main issues:
1. `aria-describedby` was only pointing to error messages, ignoring descriptions. It now combines both.
2. When `labelAsPlaceholder` is true, the visual label is hidden. We now ensure `aria-label` is set to the label text in this case, unless explicitly provided.

These changes make the forms more accessible to screen reader users by ensuring they hear descriptions and have proper labels even when using placeholder-style labels.

Verified with Playwright script and manual code inspection.

---
*PR created automatically by Jules for task [5999854877475307977](https://jules.google.com/task/5999854877475307977) started by @bimadevs*