### PR TITLE
🎨 Palette: Enhance accessibility for Input and Textarea components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,4 @@
 ## 2025-05-20 - Ambiguous Link Text
 **Learning:** Generic link text like "Read more" or "View project" creates confusion for screen reader users when navigated out of context.
 **Action:** Always attach descriptive `aria-label` props to generic links (e.g., `aria-label={`Read more about ${title}`}`).
+\n## 2025-05-23 - [Accessible Placeholder Labels]\n**Learning:** Component library inputs hide labels when `labelAsPlaceholder` is used, making them inaccessible to screen readers as placeholders are not sufficient accessible names.\n**Action:** Ensure custom inputs with hidden labels programmatically assign `aria-label` using the hidden label text.

--- a/src/once-ui/components/Input.tsx
+++ b/src/once-ui/components/Input.tsx
@@ -109,6 +109,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     const displayError = validationError || errorMessage;
 
+    const ariaDescribedBy = [
+      displayError ? `${id}-error` : undefined,
+      description ? `${id}-description` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
     const inputClassNames = classNames(styles.input, "font-body", "font-default", "font-m", {
       [styles.filled]: isFilled,
       [styles.focused]: isFocused,
@@ -163,8 +170,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={inputClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={ariaDescribedBy || undefined}
               aria-invalid={!!displayError}
+              aria-label={
+                props["aria-label"] || (labelAsPlaceholder ? label : undefined)
+              }
             />
             {!labelAsPlaceholder && (
               <Text

--- a/src/once-ui/components/Textarea.tsx
+++ b/src/once-ui/components/Textarea.tsx
@@ -125,6 +125,13 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     const displayError = validationError || errorMessage;
 
+    const ariaDescribedBy = [
+      displayError ? `${id}-error` : undefined,
+      description ? `${id}-description` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
     const textareaClassNames = classNames(
       styles.input,
       styles.textarea,
@@ -189,8 +196,11 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={textareaClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={ariaDescribedBy || undefined}
               aria-invalid={!!displayError}
+              aria-label={
+                props["aria-label"] || (labelAsPlaceholder ? label : undefined)
+              }
               style={{
                 ...style,
                 resize: lines === "auto" ? "none" : resize,


### PR DESCRIPTION
Enhanced the accessibility of `Input` and `Textarea` components in `src/once-ui`. When `labelAsPlaceholder` is true, the visual label is hidden and used as a placeholder, which is not sufficient for screen readers. This change ensures `aria-label` is set in this scenario. Additionally, the `aria-describedby` attribute now correctly links to the description text if present, improving context for assistive technologies.

---
*PR created automatically by Jules for task [11607249015179346162](https://jules.google.com/task/11607249015179346162) started by @bimadevs*