### PR TITLE
⚡ Bolt: Memoize getPosts with React.cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-05-23 - Optimizing Carousel Image Preloading
 **Learning:** Manual image preloading using `new Image()` bypasses `next/image` optimizations, leading to double downloads (unoptimized original + optimized variant).
 **Action:** Use a hidden `SmartImage` (or `next/image`) with `priority` prop to preload the next slide. This ensures the browser downloads the exact optimized URL that will be displayed.
+
+## 2026-02-10 - Caching MDX Data Fetching
+**Learning:** `getPosts` was called multiple times per request (metadata + page), causing redundant file reads. `React.cache` uses reference equality for arguments, so caching `getPosts(["arr"])` fails if the array is new each time.
+**Action:** Wrap the internal `getMDXData(dir: string)` with `React.cache` instead, as string paths are primitives and cache correctly.

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -1,6 +1,8 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
+import { cache } from "react";
+import { notFound } from 'next/navigation';
 
 type Team = {
   name: string;
@@ -19,8 +21,6 @@ type Metadata = {
   team: Team[];
   link?: string;
 };
-
-import { notFound } from 'next/navigation';
 
 function getMDXFiles(dir: string) {
   if (!fs.existsSync(dir)) {
@@ -52,7 +52,7 @@ function readMDXFile(filePath: string) {
   return { metadata, content };
 }
 
-function getMDXData(dir: string) {
+const getMDXData = cache((dir: string) => {
   const mdxFiles = getMDXFiles(dir);
   return mdxFiles.map((file) => {
     const { metadata, content } = readMDXFile(path.join(dir, file));
@@ -64,7 +64,7 @@ function getMDXData(dir: string) {
       content,
     };
   });
-}
+});
 
 export function getPosts(customPath = ["", "", "", ""]) {
   const postsDir = path.join(process.cwd(), ...customPath);


### PR DESCRIPTION
💡 What: Wrapped `getMDXData` in `React.cache`.
🎯 Why: `getPosts` is called multiple times per request (e.g. in `generateMetadata` and Page components) and also multiple times on the homepage (`Projects` component). This causes redundant file system reads and MDX parsing.
📊 Impact: Reduces disk I/O and CPU usage during rendering by deduplicating calls.
🔬 Measurement: Verify build succeeds. Functional behavior remains identical.

---
*PR created automatically by Jules for task [10059238742183927846](https://jules.google.com/task/10059238742183927846) started by @bimadevs*