### PR TITLE
⚡ Bolt: Optimize MDX file system reads using React.cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-05-23 - Optimizing Carousel Image Preloading
 **Learning:** Manual image preloading using `new Image()` bypasses `next/image` optimizations, leading to double downloads (unoptimized original + optimized variant).
 **Action:** Use a hidden `SmartImage` (or `next/image`) with `priority` prop to preload the next slide. This ensures the browser downloads the exact optimized URL that will be displayed.
+
+## 2026-02-11 - Optimizing MDX File System Reads with React Cache
+**Learning:** `getPosts` (and underlying `getMDXData`) was reading the file system multiple times per request (once for `generateMetadata`, once for page render), leading to redundant I/O.
+**Action:** Wrap data fetching functions that access the file system with `React.cache`. This request-memoizes the function, ensuring the file system is read only once per request context, even if called multiple times.


### PR DESCRIPTION
⚡ Bolt: MDX File System Read Optimization

💡 What: Wrapped `getMDXData` in `src/app/utils/utils.ts` with `React.cache`.
🎯 Why: `getPosts` (which calls `getMDXData`) is invoked multiple times during a single request (e.g., for `generateMetadata` and the page component), leading to redundant file system reads and parsing overhead.
📊 Impact: Reduces file system I/O operations by 50-66% per request for blog and work pages (reduced from ~3 reads to 1 read in shared context).
🔬 Measurement: Verified by adding temporary logs and observing that "Reading MDX data from..." appears fewer times per request in development mode.

---
*PR created automatically by Jules for task [10059744693639010145](https://jules.google.com/task/10059744693639010145) started by @bimadevs*