### PR TITLE
🎨 Palette: Improve Input and Textarea accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-20 - Ambiguous Link Text
 **Learning:** Generic link text like "Read more" or "View project" creates confusion for screen reader users when navigated out of context.
 **Action:** Always attach descriptive `aria-label` props to generic links (e.g., `aria-label={`Read more about ${title}`}`).
+
+## 2025-05-21 - Input Labels as Placeholders
+**Learning:** Using `labelAsPlaceholder` in `Input` and `Textarea` components visually hides the label, leaving the input without an accessible name if `aria-label` is not explicitly provided.
+**Action:** The components now automatically use the `label` prop as `aria-label` when `labelAsPlaceholder` is true, ensuring screen readers can still identify the field.

--- a/src/once-ui/components/Input.tsx
+++ b/src/once-ui/components/Input.tsx
@@ -163,7 +163,17 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={inputClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={
+                [
+                  displayError ? `${id}-error` : undefined,
+                  description ? `${id}-description` : undefined,
+                ]
+                  .filter(Boolean)
+                  .join(" ") || undefined
+              }
+              aria-label={
+                labelAsPlaceholder && !props["aria-label"] ? label : props["aria-label"]
+              }
               aria-invalid={!!displayError}
             />
             {!labelAsPlaceholder && (

--- a/src/once-ui/components/Textarea.tsx
+++ b/src/once-ui/components/Textarea.tsx
@@ -189,7 +189,17 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={textareaClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={
+                [
+                  displayError ? `${id}-error` : undefined,
+                  description ? `${id}-description` : undefined,
+                ]
+                  .filter(Boolean)
+                  .join(" ") || undefined
+              }
+              aria-label={
+                labelAsPlaceholder && !props["aria-label"] ? label : props["aria-label"]
+              }
               aria-invalid={!!displayError}
               style={{
                 ...style,


### PR DESCRIPTION
This PR addresses accessibility issues in `Input` and `Textarea` components.

**What:**
- When `labelAsPlaceholder` is true, the `label` prop is now automatically used as `aria-label` if no explicit `aria-label` is provided.
- The `aria-describedby` attribute now includes the ID of the description text (if present), in addition to the error message ID.

**Why:**
- Screen reader users were missing context for inputs where the label was visually presented as a placeholder.
- Helper text (descriptions) was not being programmatically associated with the input, meaning screen reader users might miss important instructions.

**Verification:**
- Verified via code review and static analysis.
- `pnpm lint` and `pnpm build` passed.
- Documented in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [14192568953516528850](https://jules.google.com/task/14192568953516528850) started by @bimadevs*