### PR TITLE
⚡ Bolt: Cache MDX file reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-05-23 - Optimizing Carousel Image Preloading
 **Learning:** Manual image preloading using `new Image()` bypasses `next/image` optimizations, leading to double downloads (unoptimized original + optimized variant).
 **Action:** Use a hidden `SmartImage` (or `next/image`) with `priority` prop to preload the next slide. This ensures the browser downloads the exact optimized URL that will be displayed.
+
+## 2025-05-24 - Deduplicating Filesystem Reads in App Router
+**Learning:** Next.js App Router components (`generateMetadata` and `page.tsx`) run in the same request but do not automatically share the result of synchronous function calls. This caused O(N) redundant filesystem reads for every blog post request.
+**Action:** Wrap expensive data fetching functions (like `getMDXData`) with `React.cache`. This memoizes the result for the duration of the request, ensuring the filesystem is read only once per directory per request.

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
+import { cache } from "react";
 
 type Team = {
   name: string;
@@ -52,7 +53,9 @@ function readMDXFile(filePath: string) {
   return { metadata, content };
 }
 
-function getMDXData(dir: string) {
+// Wrap getMDXData with cache to deduplicate file system reads
+// when called multiple times in the same request (e.g. metadata + page)
+const getMDXData = cache((dir: string) => {
   const mdxFiles = getMDXFiles(dir);
   return mdxFiles.map((file) => {
     const { metadata, content } = readMDXFile(path.join(dir, file));
@@ -64,7 +67,7 @@ function getMDXData(dir: string) {
       content,
     };
   });
-}
+});
 
 export function getPosts(customPath = ["", "", "", ""]) {
   const postsDir = path.join(process.cwd(), ...customPath);


### PR DESCRIPTION
💡 What: Wrapped getMDXData in React.cache to deduplicate file system reads.
🎯 Why: Redundant file reads were occurring multiple times per request (metadata + page).
📊 Impact: Reduces file system reads by ~50% per request.
🔬 Measurement: Verified via logs that "Reading MDX data" occurs only once per directory per request.

---
*PR created automatically by Jules for task [8453344331563126340](https://jules.google.com/task/8453344331563126340) started by @bimadevs*