### PR TITLE
feat(a11y): enhance form inputs accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-20 - Ambiguous Link Text
 **Learning:** Generic link text like "Read more" or "View project" creates confusion for screen reader users when navigated out of context.
 **Action:** Always attach descriptive `aria-label` props to generic links (e.g., `aria-label={`Read more about ${title}`}`).
+
+## 2025-10-27 - Form Accessibility Gaps
+**Learning:** Inputs with `labelAsPlaceholder` lack accessible names because the `<label>` is removed. Also, `aria-describedby` often misses description text, linking only to errors.
+**Action:** Programmatically set `aria-label` to the `label` prop when `labelAsPlaceholder` is true. Ensure `aria-describedby` combines both error and description IDs.

--- a/src/once-ui/components/Input.tsx
+++ b/src/once-ui/components/Input.tsx
@@ -109,6 +109,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     const displayError = validationError || errorMessage;
 
+    const ariaDescribedBy = [
+      displayError ? `${id}-error` : undefined,
+      description ? `${id}-description` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
     const inputClassNames = classNames(styles.input, "font-body", "font-default", "font-m", {
       [styles.filled]: isFilled,
       [styles.focused]: isFocused,
@@ -163,8 +170,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={inputClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={ariaDescribedBy}
               aria-invalid={!!displayError}
+              aria-label={labelAsPlaceholder && !props["aria-label"] ? label : props["aria-label"]}
             />
             {!labelAsPlaceholder && (
               <Text

--- a/src/once-ui/components/PasswordInput.tsx
+++ b/src/once-ui/components/PasswordInput.tsx
@@ -20,6 +20,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, InputProps>((props, re
           icon={showPassword ? "eyeOff" : "eye"}
           size="s"
           type="button"
+          aria-label={showPassword ? "Hide password" : "Show password"}
         />
       }
     />

--- a/src/once-ui/components/Textarea.tsx
+++ b/src/once-ui/components/Textarea.tsx
@@ -125,6 +125,13 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     const displayError = validationError || errorMessage;
 
+    const ariaDescribedBy = [
+      displayError ? `${id}-error` : undefined,
+      description ? `${id}-description` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
     const textareaClassNames = classNames(
       styles.input,
       styles.textarea,
@@ -189,8 +196,9 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
               onFocus={handleFocus}
               onBlur={handleBlur}
               className={textareaClassNames}
-              aria-describedby={displayError ? `${id}-error` : undefined}
+              aria-describedby={ariaDescribedBy}
               aria-invalid={!!displayError}
+              aria-label={labelAsPlaceholder && !props["aria-label"] ? label : props["aria-label"]}
               style={{
                 ...style,
                 resize: lines === "auto" ? "none" : resize,


### PR DESCRIPTION
This PR addresses critical accessibility gaps in form components:
1.  **Missing Accessible Names:** When `labelAsPlaceholder` is used, the visual label is removed. This change ensures the input still has an accessible name by falling back to the `label` prop via `aria-label`.
2.  **Incomplete Descriptions:** Previously, `aria-describedby` only linked to error messages. It now correctly includes the helper text (`description` prop) as well.
3.  **Password Toggle:** The "show/hide password" button now has a dynamic accessible label ("Show password" / "Hide password") instead of relying on the icon name.

---
*PR created automatically by Jules for task [8730595323827693676](https://jules.google.com/task/8730595323827693676) started by @bimadevs*