### PR TITLE
🎨 Palette: Enhance Carousel Accessibility

### DIFF
--- a/src/once-ui/components/Carousel.tsx
+++ b/src/once-ui/components/Carousel.tsx
@@ -39,6 +39,15 @@ const Carousel: React.FC<CarouselProps> = ({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (images.length > 1) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleImageClick();
+      }
+    }
+  };
+
   const handleControlClick = (nextIndex: number) => {
     if (nextIndex !== activeIndex && !transitionTimeoutRef.current) {
       setNextIndexToPreload(nextIndex);
@@ -77,6 +86,10 @@ const Carousel: React.FC<CarouselProps> = ({
     <Flex fillWidth gap="12" direction="column" {...rest}>
       <RevealFx
         onClick={handleImageClick}
+        onKeyDown={handleKeyDown}
+        role={images.length > 1 ? "button" : undefined}
+        tabIndex={images.length > 1 ? 0 : undefined}
+        aria-label={images.length > 1 ? "Next slide" : undefined}
         fillWidth
         trigger={isTransitioning}
         translateY="16"


### PR DESCRIPTION
This PR improves the accessibility of the `Carousel` component by making the main image area interactive for keyboard users and screen readers when there are multiple images. It adds `role="button"`, `tabIndex={0}`, and an `aria-label`, along with an `onKeyDown` handler to support navigation via Enter and Space keys.

---
*PR created automatically by Jules for task [7705836282464906553](https://jules.google.com/task/7705836282464906553) started by @bimadevs*