### PR TITLE
🎨 Palette: Add accessible labels to password toggle

### DIFF
--- a/src/once-ui/components/PasswordInput.tsx
+++ b/src/once-ui/components/PasswordInput.tsx
@@ -18,6 +18,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, InputProps>((props, re
           }}
           variant="ghost"
           icon={showPassword ? "eyeOff" : "eye"}
+          tooltip={showPassword ? "Hide password" : "Show password"}
           size="s"
           type="button"
         />


### PR DESCRIPTION
💡 What: Added a dynamic `tooltip` (which sets `aria-label`) to the password visibility toggle in `PasswordInput`.
🎯 Why: The default label was just the icon name ("eye" or "eyeOff"), which is confusing for screen reader users.
♿ Accessibility: The toggle now announces 'Show password' or 'Hide password' depending on state.

---
*PR created automatically by Jules for task [9773130586506855699](https://jules.google.com/task/9773130586506855699) started by @bimadevs*