### PR TITLE
fix(og): inline OG data to reduce Edge Function bundle below 1MB

### DIFF
--- a/.omo/run-continuation/ses_0f2815a96ffe7SibdHG7HBMDbr.json
+++ b/.omo/run-continuation/ses_0f2815a96ffe7SibdHG7HBMDbr.json
@@ -1,10 +1,10 @@
 {
   "sessionID": "ses_0f2815a96ffe7SibdHG7HBMDbr",
-  "updatedAt": "2026-06-28T09:53:59.395Z",
+  "updatedAt": "2026-06-28T09:57:02.232Z",
   "sources": {
     "background-task": {
       "state": "idle",
-      "updatedAt": "2026-06-28T09:53:59.395Z"
+      "updatedAt": "2026-06-28T09:57:02.232Z"
     }
   }
 }

--- a/src/app/og/route.tsx
+++ b/src/app/og/route.tsx
@@ -1,6 +1,9 @@
 import { ImageResponse } from "next/og";
-import { baseURL } from "@/app/resources";
-import { person } from "@/app/resources/content";
+
+// Import langsung dari source file (bukan barrel/index.ts)
+// untuk menghindari bundle 66+ komponen once-ui ke Edge Function
+const baseURL = "bimadev.online";
+const person = { name: "Bima", role: "FullStack Developer" };
 
 export const runtime = "edge";
 


### PR DESCRIPTION
## Fix: OG Route Edge Function Size

### Issue
Deploy Vercel gagal karena Edge Function `og` size 1.08MB melebihi limit free plan (1MB).

### Root Cause
Import chain yang gak sengaja bundle 66+ komponen once-ui:
```
og/route.tsx -> @/app/resources (barrel index.ts)
              -> content.jsx -> import { InlineCode }
              -> @/once-ui/components/index.ts -> re-exports semua komponen
              -> framer-motion, GSAP, dll -> bundle 1.08MB
```

### Fix
Ganti import dari barrel `@/app/resources` ke inline data langsung di OG route. Zero dependency chain, bundle jauh di bawah 1MB.

### Verification
- pnpm build sukses
- OG route returns image/png 200 OK
- OG renders dengan title + person data