### PR TITLE
feat: replace hero section with MinimalistHero layout + Tailwind CSS

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import classNames from "classnames";
 
 import { Fade, Flex, Line, ToggleButton } from "@/once-ui/components";
 import styles from "@/components/Header.module.scss";
@@ -50,11 +51,11 @@ export const Header = () => {
 
   return (
     <>
-      <Fade hide="s" fillWidth position="fixed" height="80" zIndex={9} />
-      <Fade show="s" fillWidth position="fixed" bottom="0" to="top" height="80" zIndex={9} />
+      <Fade hide="s" fillWidth position="fixed" height="80" zIndex={9} className="z-40" />
+      <Fade show="s" fillWidth position="fixed" bottom="0" to="top" height="80" zIndex={9} className="z-40" />
       <Flex
         fitHeight
-        className={styles.position}
+        className={classNames(styles.position, "z-40")}
         as="header"
         zIndex={9}
         fillWidth


### PR DESCRIPTION
## Changes

- Replace old inline hero (TrueFocus + Avatar) with new MinimalistHero component
- Install Tailwind CSS v4 + lucide-react
- Add conditional PageLayout wrapper — hero spans full-width on homepage, other pages keep original padding
- Fix circle color to match brand blue, reduce overlap with new image
- Adjusted layout stacking so menu bar floats above hero image (z-index 40)
- Profile image replaces generic logo in hero

## Commits

- `chore(deps): add Tailwind CSS v4 and lucide-react`
- `feat: add MinimalistHero component and PageLayout wrapper`
- `feat: integrate MinimalistHero into homepage layout`
- `feat: add profile image for hero section`
- `fix: raise navbar z-index above hero image overlap`